### PR TITLE
Usa nombre correcto de variable 

### DIFF
--- a/api/controllers/LawController.js
+++ b/api/controllers/LawController.js
@@ -48,7 +48,7 @@ module.exports = {
   },
 
   newLaw: function(req, res) {
-    Tag.find({}).exec(function(err, laws) {
+    Tag.find({}).exec(function(err, tags) {
       if (err) return res.send(500, err);
       return res.view('law/new', {tags: tags});
     });


### PR DESCRIPTION
El acceder a `http://localhost:1337/ley/law/new` hace que el server se caiga, ya que se quiere regresar la variable `tags`, la cual es inexistente.
