### PR TITLE
Adding COLABORA.md

### DIFF
--- a/COLABORA.md
+++ b/COLABORA.md
@@ -1,0 +1,43 @@
+# Colabora con "Cambia la Ley" ([english](/CONTRIBUTE.md))
+
+1. [Cómo colaborar](#cómo-colaborar)
+2. [Discusión](#discusión)
+3. [Sobre los pull requests](#sobre-pull-requests)
+4. [Sobre autores y colaboradores](#sobre-autores-y-colaboradores)
+
+
+
+## Cómo colaborar
+Puedes colaborar de las siguientes formas:
+- Reportando errores o bugs
+
+  Puedes reportar bugs en nuestra página de [issues](https://github.com/CodeandoMexico/cambia-la-ley/issues). Sólo asegúrate de usar la etiqueta "bug". Ayúdanos siendo lo más específico(a) posible, preferentemente incluyendo tanto registros de códigos de error, como capturas de pantalla. Si puedes arreglar el bug tú mismo(a), manda un pull-request.
+
+- Sugiriendo cambios
+
+  Igual que al reportar errores, puedes sugerir cambios o nuevas funcionalidades en la página de [issues](https://github.com/CodeandoMexico/cambia-la-ley/issues). Por favor, incluye una descripción lo más específica posible. Nos encanta cuando las sugerencias están acompañadas de un pull-request.
+
+- Colaborando con el código
+
+  Si es que no hemos enfatizado lo suficiente: *¡Nos encantan los pull-requests!*. Estamos en una etapa de agregarle más pruebas(*testing*) al proyecto, por ende preferiremos los pull-requests con tests. El equipo base te contestará con por lo menos un comentario a cada pull-request en un lapso de 3 días hábiles.
+
+## Discusión
+Por favor, utiliza nuesta página de [issues](https://github.com/CodeandoMexico/cambia-la-ley/issues) para cualquier discusión.
+
+## Sobre los pull requests
+  Estamos en una etapa de mejora, agegando tests con Mocha y Should.js. A pesar de que aún no tenemos bien definido un test framework, preferimos que cada pull-request venga acompañado de tests. Cada pull-request deberá:
+  - Referenciar un problema en el commit. Ejemplo de mensaje de commit: [#23] Mejora el desempeño de la base de datos.
+  - Dar una explicación clara de cuál es la razón de ser de ese pull-request. La explicación se deberá llevar a cabo en la sección de comentarios del pull-request en github.
+
+  El equipo base se compromete a contestar cualquier pull-request en un lapso de 3 días hábiles con al menos un comentario.
+
+## Sobre autores y colaboradores
+
+### Autores
+Los authors son aquellos colaboradores que tuvieron la idea original, y normalmente son quienes hicieron el primer grupo de commits.
+
+### Colaboradores
+Son personas que han colaborado con cambios en el código, documentación o solución de bugs en el proyecto, a través de un pull request. Estos deberán ser ordenados según la fecha de colaboración inicial en el archivo [CONTRIBUTORS.md](/CONTRIBUTORS.md).
+
+### Equipo base
+Es el responsable por el desarrollo y mantenimiento del proyecto. Tiene el compromiso de responder a los pull requests y dirigir la discusión sobre el proyecto. En nuestro caso, el equipo base son normalmente miembros de Codeando México.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to "Cambia la Ley" ([español](/CONTRIBUYE.md))
+# Contributing to "Cambia la Ley" ([español](/COLABORA.md))
 
 1. [Getting involved](#getting-involved)
 2. [Discussion](#discussion)


### PR DESCRIPTION
Adding COLABORA.md which is a translation to spanish from CONTRIBUTING.md. Changed name from CONTRIBUYE to COLABORA because "Contributors" would translate as "Contribuyentes" and unless you are the SAT and able to charge taxes, that won't be convenient.